### PR TITLE
fix: #2 stdout max buffer exceeded

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Note that unpublishing does not work on the main NPM registry, however this modu
 
 ## Install
 
-```
-$ npm install snapshot-publish
+```sh
+ $ npm install snapshot-publish
 ```
 
 ## Usage
@@ -19,23 +19,39 @@ $ npm install snapshot-publish
 ```js
 const publish = require('snapshot-publish');
 
-publish().then(function () {
-	console.log('A new version has been published!');
+publish().then(function (npmPublishOutput) {
+  console.log('A new version has been published!');
 });
 ```
 
 ## API
 
-### snapshotPublish([cwd])
+### snapshotPublish([opts])
 
 Returns a promise that is resolved when the package has been published.
 
+#### opts
+
 #### cwd
 
-Type: `string`  
+Type: `string`
 Default: `.`
 
 Directory to start looking for a package.json file.
+
+#### redirectOutput
+
+type: `bool`
+Default: `false`
+
+Redirect npm cmd output to stdout/err
+
+#### maxBufferSize
+
+type: `integer`
+Default: 2000 * 1024
+
+Maximum amount of output buffer from npm publish commands, up this if you have a lot of output from your npm scripts and this script throws
 
 ## Licence
 

--- a/index.js
+++ b/index.js
@@ -84,8 +84,9 @@ module.exports = function (opts) {
       const exec = childProcess.exec(cmd, {cwd: opts.cwd, maxBuffer: opts.maxBufferSize}, function (error, stdout, stderr) {
         if (error) {
           reject(stderr);
+        } else {
+          resolve(stdout);
         }
-        resolve(stdout);
       });
 
       if (opts.redirectOutput) {

--- a/index.js
+++ b/index.js
@@ -1,14 +1,19 @@
 'use strict';
 const readPkgUp = require('read-pkg-up');
-const pify = require('pify');
 const semver = require('semver');
-const childProcess = pify(require('child_process'));
+const childProcess = require('child_process');
 
 const STDOUT_BUFFER_SIZE = 2000 * 1024;
 const POSSIBLE_TAGS = {
   snapshot: /^snapshot$/i,
   candidate: /^rc\d*$/i,
   milestone: /^m\d+$/i
+};
+
+const DEFAULT_OPTIONS = {
+  redirectOutput: false,
+  maxBufferSize: STDOUT_BUFFER_SIZE,
+  cwd: '.'
 };
 
 function getDistTagForTag(tag) {
@@ -49,14 +54,17 @@ function getDistTagForVersion(version) {
   return matchingDistTags.length === 1 ? matchingDistTags[0] : null;
 }
 
-module.exports = function (cwd) {
-  if (cwd === undefined) {
-    cwd = '.';
+module.exports = function (opts) {
+  // default opts is cwd, for backwards compatibility
+  if (typeof opts === 'string') {
+    opts = {cwd: opts};
   }
+
+  opts = Object.assign({}, DEFAULT_OPTIONS, opts);
 
   function publish(distTag) {
     const publishCommand = 'npm publish' + (distTag ? ' --tag ' + distTag : '');
-    return childProcess.exec(publishCommand, {cwd: cwd, maxBuffer: STDOUT_BUFFER_SIZE});
+    return exec(publishCommand);
   }
 
   function publishPackage(packageObj) {
@@ -64,12 +72,28 @@ module.exports = function (cwd) {
     const distTag = getDistTagForVersion(version);
 
     if (distTag === 'snapshot') {
-      return childProcess.exec('npm unpublish --force', {cwd: cwd, maxBuffer: STDOUT_BUFFER_SIZE})
+      return exec('npm unpublish --force')
         .then(publish.bind(undefined, distTag));
     }
 
     return publish(distTag === null ? undefined : distTag);
   }
 
-  return readPkgUp({cwd: cwd}).then(publishPackage);
+  function exec(cmd) {
+    return new Promise(function (resolve, reject) {
+      const exec = childProcess.exec(cmd, {cwd: opts.cwd, maxBuffer: opts.maxBufferSize}, function (error, stdout, stderr) {
+        if (error) {
+          reject(stderr);
+        }
+        resolve(stdout);
+      });
+
+      if (opts.redirectOutput) {
+        exec.stdout.pipe(process.stdout);
+        exec.stderr.pipe(process.stderr);
+      }
+    });
+  }
+
+  return readPkgUp({cwd: opts.cwd}).then(publishPackage);
 };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "author": "Keir Lawson",
   "license": "MIT",
   "dependencies": {
-    "pify": "^2.3.0",
     "read-pkg-up": "^1.0.1",
     "semver": "^5.5.0"
   },


### PR DESCRIPTION
Added options to redirect output of npm publish commands to std out and also updated examples to show that stdout is returned.

Removed pify require